### PR TITLE
main.yaml: Remove deprecated parameter

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -19,9 +19,7 @@
   when: "force_reregistration|bool"
 
 - name: "Detect if katello-ca-consumer* package is installed"
-  command: rpm -qf /usr/bin/katello-rhsm-consumer
-  args:
-    warn: false
+  ansible.builtin.command: rpm -qf /usr/bin/katello-rhsm-consumer
   failed_when: false
   changed_when: false
   register: rpm_q_katello_ca_consumer


### PR DESCRIPTION
It will make the role fail if executed with Ansible 2.14:

~~~
Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: argv, stdin, _raw_params, creates, executable, removes, strip_empty_ends, stdin_add_newline, _uses_shell, chdir. ~~~