### PR TITLE
feat(defaults/main.yml): Set default for `repo_ca_cert`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ server_port: 443
 server_prefix: /subscription
 rhsm_baseurl: https://cdn.redhat.com
 rhsm_ca_cert_dir: /etc/rhsm/ca/
-rhsm_repo_ca_cert: /etc/rhsm/ca/redhat-uep.pem
+rhsm_repo_ca_cert: '%(ca_cert_dir)sredhat-uep.pem'
 
 activationkey: null
 username: null


### PR DESCRIPTION
Use the one that comes out of the system.